### PR TITLE
@sti.admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # app-dev
 My first respiratory
+| Series | Actors |
+| ----------- | ----------- |
+| Wednesday | Wednesday Addams |
+| The Girl From Nowhere | Chicha Amatayakul |


### PR DESCRIPTION
Wednesday is the latest live-action adaptation of The Addams Family franchise coming to Netflix on November 23, 2022. As the director, Tim Burton wanted to make sure that this new series would not be mistaken for a remake or a reboot, but a spinoff that focuses on an entirely new chapter of Wednesday’s life as she grows into adulthood. The main members of the Addams Family are all well-known and beloved, based on the original characters by Charles Addams. However, this version of Wednesday is much older than when we last saw her as portrayed by Christina Ricci. Now that Wednesday is of high school age, there are bound to be new faces in her life, both friends and foes. Watch the official trailer below if you haven’t seen it yet!  The plot revolves around Nanno, an enigmatic girl who transfers to different private schools in Thailand and exposes the students and faculty's stories of lies, secrets, and hypocrisy. Nanno on occasion lies to provoke others. She is revealed to be an immortal entity, punishing wrongdoers for their crimes and misdeeds. In Season 2, Nanno meets her match in newfound rival Yuri, who has a different, more revenge focused ideology and wants to take over Nanno's duties.